### PR TITLE
vagrant-smartos-zones plugin check and install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,13 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  unless Vagrant.has_plugin?('vagrant-smartos-zones')
+    puts "vagrant-smartos-zones plugin is missing. Installing..."
+    %x(set -x; vagrant plugin install vagrant-smartos-zones)
+    puts "Now try again."
+    exit
+  end
+
   config.vm.provider "virtualbox" do |v|
     v.memory = 3072
   end


### PR DESCRIPTION
With just vagrant installed, starting from the vagrantcloud box [smartos-base64-13.4.0](https://vagrantcloud.com/livinginthepast/smartos-base64-13.4.0):

```
$ vagrant init livinginthepast/smartos-base64-13.4.0
[...]
$ vagrant up
[...]
Vagrant:
* Unknown configuration section 'global_zone'.
```

This commit modifies the box Vagrantfile to check for the plugin and install it using a subshell. 

```
lab $ vagrant up
vagrant-smartos-zones plugin is missing. Installing...
+ vagrant plugin install vagrant-smartos-zones
Now try again.
```

Vagrant currently lacks box/plugin dependencies, but apparently this [will be addressed](https://github.com/mitchellh/vagrant/issues/1874#issuecomment-27560440), in which case this should be reviewed.

/cc @sax, @khushil
