### PR TITLE
Use VirtualBoxVM that accepts --startvm

### DIFF
--- a/bin/mksmartvm
+++ b/bin/mksmartvm
@@ -17,8 +17,8 @@ usage() {
   echo "  -p --sshport    SSH port to forward (default 2222)"
 }
 
-DISKSIZE="32"
-MEMSIZE="1024"
+DISKSIZE="100"
+MEMSIZE="2048"
 SSHPORT="2222"
 
 while getopts ":d:m:p:" arg; do
@@ -39,4 +39,4 @@ echo
 echo "Starting Virtual Machine"
 echo "  Hint: use defaults"
 echo "  Hint: set root password to 'vagrant'"
-VirtualBox --startvm "${vmname}" &
+VirtualBoxVM --startvm "${vmname}" &


### PR DESCRIPTION
Since VirtualBox v6, --startvm is only a valid flag on VirtualBoxVM (it used to be accepted by manager which was passing it to VirtualBoxVM, but they removed that indirection).

Also increased default sizes.